### PR TITLE
linux: start function interface fix

### DIFF
--- a/pyvirtualcam/native_linux/main.cpp
+++ b/pyvirtualcam/native_linux/main.cpp
@@ -5,8 +5,7 @@
 
 namespace py = pybind11;
 
-void start(uint32_t width, uint32_t height, double fps, int delay) {
-    (void)delay;
+void start(uint32_t width, uint32_t height, double fps) {
     if (!virtual_output_start(width, height, fps))
         throw std::runtime_error("error starting virtual camera output");
 }


### PR DESCRIPTION
Thank you for your repo. It is helpful.

I was checking the repository in my environment.
Ubuntu 18.04.05 LTS, python3.6.9, pybind11-2.6.2, gcc 7.5.0

I faced test failure using the provided test files in master branch. Failure screenshot attached.
![test_summary](https://user-images.githubusercontent.com/11979363/110236264-09533200-7f5f-11eb-9539-ad895c894734.png)

This happened due to mismatch of main.cpp's start function interface and NativeCameraBackend's _native.start calling difference
![error](https://user-images.githubusercontent.com/11979363/110236324-52a38180-7f5f-11eb-978b-e6ce93f74522.png)

I have seen that you have solved it in linux-ci branch by changing camera.py code but I think if we don't provide the delay variable, it can be solved without camera.py change and in same branch  and this delay variable is not used by any code. What is the purpose of delay?
Am I right that you have used,
`(void)delay;`
to try to solve [this](https://stackoverflow.com/q/7354786/6511525)

I have tested the change using provided test code. It has passed with 1 warnings.
![passed](https://user-images.githubusercontent.com/11979363/110236330-5800cc00-7f5f-11eb-8bfb-2b25cb7055d0.png)
