### PR TITLE
Pixel formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Support for common pixel formats: RGB (default), BGR (useful for OpenCV), GRAY, I420, YUYV.
+
+### Removed
+- RGBA support has been removed. Use RGB instead.
+
 ## [0.5.0] - 2012-03-13
 ### Added
 - Linux: multiple camera support (#37).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ with pyvirtualcam.Camera(width=1280, height=720, fps=20) as cam:
         cam.sleep_until_next_frame()
 ```
 
-For more examples, check out the [`samples/`](samples) folder.
+For more examples, including using different pixel formats like BGR, check out the [`samples/`](samples) folder.
 
 ## Installation
 

--- a/pyvirtualcam/__init__.py
+++ b/pyvirtualcam/__init__.py
@@ -1,3 +1,3 @@
 from ._version import __version__
 
-from .camera import Camera, BACKENDS
+from .camera import Camera, PixelFormat, BACKENDS

--- a/pyvirtualcam/camera.py
+++ b/pyvirtualcam/camera.py
@@ -3,7 +3,6 @@ import platform
 import time
 import warnings
 from enum import Enum
-from collections import namedtuple
 
 import numpy as np
 

--- a/pyvirtualcam/camera.py
+++ b/pyvirtualcam/camera.py
@@ -25,6 +25,7 @@ class PixelFormat(Enum):
     # See external/libyuv/include/libyuv/video_common.h for fourcc codes.
     RGB = 'raw ', lambda w, h: (h, w, 3)
     BGR = '24BG', lambda w, h: (h, w, 3)
+    GRAY = 'J400', lambda w, h: (h, w)
     I420 = 'I420', lambda w, h: (w + w // 2) * h
     YUYV = 'YUY2', lambda w, h: h * w * 2
 

--- a/pyvirtualcam/camera.py
+++ b/pyvirtualcam/camera.py
@@ -62,15 +62,15 @@ class Camera:
 
         frame_shape = fmt.value[1](width, height)
         if isinstance(frame_shape, int):
-            def check_frame(frame: np.ndarray):
+            def check_frame_shape(frame: np.ndarray):
                 if frame.size != frame_shape:
                     raise ValueError(f"unexpected frame size: {frame.size} != {frame_shape}")
         else:
-            def check_frame(frame: np.ndarray):
+            def check_frame_shape(frame: np.ndarray):
                 if frame.shape != frame_shape:
                     raise ValueError(f"unexpected frame shape: {frame.shape} != {frame_shape}")
 
-        self._check_frame = check_frame
+        self._check_frame_shape = check_frame_shape
 
         self._fps_counter = FPSCounter(fps)
         self._fps_last_printed = time.perf_counter()
@@ -124,7 +124,10 @@ class Camera:
         self._backend.close()
 
     def send(self, frame: np.ndarray) -> None:
-        self._check_frame(frame)
+        if frame.dtype != np.uint8:
+            raise TypeError(f'unexpected frame dtype: {frame.dtype} != uint8')
+        
+        self._check_frame_shape(frame)
 
         self._frames_sent += 1
         self._last_frame_t = time.perf_counter()

--- a/pyvirtualcam/camera.py
+++ b/pyvirtualcam/camera.py
@@ -64,11 +64,11 @@ class Camera:
         if isinstance(frame_shape, int):
             def check_frame(frame: np.ndarray):
                 if frame.size != frame_shape:
-                    raise ValueError(f"mismatching frame size: {frame.size} != {frame_shape}")
+                    raise ValueError(f"unexpected frame size: {frame.size} != {frame_shape}")
         else:
             def check_frame(frame: np.ndarray):
                 if frame.shape != frame_shape:
-                    raise ValueError(f"unexpected frame shape: {frame.shape} != ({frame_shape})")
+                    raise ValueError(f"unexpected frame shape: {frame.shape} != {frame_shape}")
 
         self._check_frame = check_frame
 

--- a/pyvirtualcam/native_linux_v4l2loopback/main.cpp
+++ b/pyvirtualcam/native_linux_v4l2loopback/main.cpp
@@ -10,8 +10,8 @@ class Camera {
     VirtualOutput virtual_output;
 
   public:
-    Camera(uint32_t width, uint32_t height, [[maybe_unused]] double fps)
-     : virtual_output {width, height} {
+    Camera(uint32_t width, uint32_t height, [[maybe_unused]] double fps, uint32_t fourcc)
+     : virtual_output {width, height, fourcc} {
     }
 
     void close() {
@@ -30,8 +30,9 @@ class Camera {
 
 PYBIND11_MODULE(_native_linux_v4l2loopback, m) {
     py::class_<Camera>(m, "Camera")
-        .def(py::init<uint32_t, uint32_t, double>(),
-             py::arg("width"), py::arg("height"), py::arg("fps"))
+        .def(py::init<uint32_t, uint32_t, double, uint32_t>(),
+             py::arg("width"), py::arg("height"), py::arg("fps"),
+             py::kw_only(), py::arg("fmt"))
         .def("close", &Camera::close)
         .def("send", &Camera::send)
         .def("device", &Camera::device);

--- a/pyvirtualcam/native_linux_v4l2loopback/virtual_output.h
+++ b/pyvirtualcam/native_linux_v4l2loopback/virtual_output.h
@@ -42,14 +42,23 @@ class VirtualOutput {
         frame_fmt = libyuv::CanonicalFourCC(fourcc);
         out_frame_size = i420_frame_size(width, height);
 
+        uint32_t out_frame_fmt_v4l;
+
         switch (frame_fmt) {
             case libyuv::FOURCC_RAW:
             case libyuv::FOURCC_24BG:
+                // RGB|BGR -> I420
                 buffer_output.resize(out_frame_size);
+                out_frame_fmt_v4l = V4L2_PIX_FMT_YUV420;
                 break;
             case libyuv::FOURCC_J400:
+                out_frame_fmt_v4l = V4L2_PIX_FMT_GREY;
+                break;
             case libyuv::FOURCC_I420:
+                out_frame_fmt_v4l = V4L2_PIX_FMT_YUV420;
+                break;
             case libyuv::FOURCC_YUY2:
+                out_frame_fmt_v4l = V4L2_PIX_FMT_YUYV;
                 break;
             default:
                 throw std::runtime_error(
@@ -107,13 +116,7 @@ class VirtualOutput {
         v4l2_pix_format& pix = v4l2_fmt.fmt.pix;
         pix.width = width;
         pix.height = height;
-        if (frame_fmt == libyuv::FOURCC_YUY2) {
-            pix.pixelformat = V4L2_PIX_FMT_YUYV;
-        } else if (frame_fmt == libyuv::FOURCC_J400) {
-            pix.pixelformat = V4L2_PIX_FMT_GREY;
-        } else {
-            pix.pixelformat = V4L2_PIX_FMT_YUV420;
-        }
+        pix.pixelformat = out_frame_fmt_v4l;
 
         // v4l2loopback sets bytesperline, sizeimage, and colorspace for us.
 

--- a/pyvirtualcam/native_linux_v4l2loopback/virtual_output.h
+++ b/pyvirtualcam/native_linux_v4l2loopback/virtual_output.h
@@ -47,12 +47,13 @@ class VirtualOutput {
             case libyuv::FOURCC_24BG:
                 buffer_output.resize(out_frame_size);
                 break;
+            case libyuv::FOURCC_J400:
             case libyuv::FOURCC_I420:
             case libyuv::FOURCC_YUY2:
                 break;
             default:
                 throw std::runtime_error(
-                    "Unsupported image format, must be RGB, BGR, I420, or YUYV."
+                    "Unsupported image format, must be RGB, BGR, GRAY, I420, or YUYV."
                 );
         }
 
@@ -108,6 +109,8 @@ class VirtualOutput {
         pix.height = height;
         if (frame_fmt == libyuv::FOURCC_YUY2) {
             pix.pixelformat = V4L2_PIX_FMT_YUYV;
+        } else if (frame_fmt == libyuv::FOURCC_J400) {
+            pix.pixelformat = V4L2_PIX_FMT_GREY;
         } else {
             pix.pixelformat = V4L2_PIX_FMT_YUV420;
         }
@@ -155,6 +158,7 @@ class VirtualOutput {
                 out_frame = buffer_output.data();
                 bgr_to_i420(frame, out_frame, frame_width, frame_height);
                 break;
+            case libyuv::FOURCC_J400:
             case libyuv::FOURCC_I420:
             case libyuv::FOURCC_YUY2:
                 out_frame = const_cast<uint8_t*>(frame);

--- a/pyvirtualcam/native_macos_obs/main.mm
+++ b/pyvirtualcam/native_macos_obs/main.mm
@@ -12,8 +12,8 @@ class Camera {
     VirtualOutput virtual_output;
 
   public:
-    Camera(uint32_t width, uint32_t height, double fps)
-     : virtual_output {width, height, fps} {
+    Camera(uint32_t width, uint32_t height, double fps, uint32_t fourcc)
+     : virtual_output {width, height, fps, fourcc} {
     }
 
     void close() {
@@ -32,8 +32,9 @@ class Camera {
 
 PYBIND11_MODULE(_native_macos_obs, m) {
     py::class_<Camera>(m, "Camera")
-        .def(py::init<uint32_t, uint32_t, double>(),
-             py::arg("width"), py::arg("height"), py::arg("fps"))
+        .def(py::init<uint32_t, uint32_t, double, uint32_t>(),
+             py::arg("width"), py::arg("height"), py::arg("fps"),
+             py::kw_only(), py::arg("fmt"))
         .def("close", &Camera::close)
         .def("send", &Camera::send)
         .def("device", &Camera::device);

--- a/pyvirtualcam/native_macos_obs/virtual_output.h
+++ b/pyvirtualcam/native_macos_obs/virtual_output.h
@@ -117,26 +117,24 @@ class VirtualOutput {
         
         uint64_t timestamp = mach_absolute_time();
 
+        uint8_t* tmp = buffer_tmp.data();
         uint8_t* uyvy = buffer_output.data();
         
         switch (frame_fmt) {
             case libyuv::FOURCC_RAW:            
-                uint8_t* argb = buffer_tmp.data();
-                rgb_to_argb(frame, argb, frame_width, frame_height);
-                argb_to_uyvy(argb, uyvy, frame_width, frame_height);
+                rgb_to_argb(frame, tmp, frame_width, frame_height);
+                argb_to_uyvy(tmp, uyvy, frame_width, frame_height);
                 break;
             case libyuv::FOURCC_24BG:
-                uint8_t* argb = buffer_tmp.data();
-                bgr_to_argb(frame, argb, frame_width, frame_height);
-                argb_to_uyvy(argb, uyvy, frame_width, frame_height);
+                bgr_to_argb(frame, tmp, frame_width, frame_height);
+                argb_to_uyvy(tmp, uyvy, frame_width, frame_height);
                 break;
             case libyuv::FOURCC_I420:
                 i420_to_uyvy(frame, uyvy, frame_width, frame_height);
                 break;
             case libyuv::FOURCC_YUY2:
-                uint8_t* i422 = buffer_tmp.data();
-                yuyv_to_i422(frame, i422, frame_width, frame_height);
-                i422_to_uyvy(i422, uyvy, frame_width, frame_height);
+                yuyv_to_i422(frame, tmp, frame_width, frame_height);
+                i422_to_uyvy(tmp, uyvy, frame_width, frame_height);
                 break;
             default:
                 throw std::logic_error("not implemented");

--- a/pyvirtualcam/native_macos_obs/virtual_output.h
+++ b/pyvirtualcam/native_macos_obs/virtual_output.h
@@ -33,13 +33,14 @@ class VirtualOutput {
     OBSDALMachServer* mach_server = nil;
     uint32_t frame_width;
     uint32_t frame_height;
+    uint32_t frame_fmt;
     uint32_t fps_num;
     uint32_t fps_den;
-    std::vector<uint8_t> buffer_argb;
+    std::vector<uint8_t> buffer_tmp;
     std::vector<uint8_t> buffer_output;
 
   public:
-    VirtualOutput(uint32_t width, uint32_t height, double fps) {
+    VirtualOutput(uint32_t width, uint32_t height, double fps, uint32_t fourcc) {
         NSString *dal_plugin_path = @"/Library/CoreMediaIO/Plug-Ins/DAL/obs-mac-virtualcam.plugin";
         NSFileManager *file_manager = [NSFileManager defaultManager];
         BOOL dal_plugin_installed = [file_manager fileExistsAtPath:dal_plugin_path];
@@ -50,12 +51,30 @@ class VirtualOutput {
                 );
         }
 
+        frame_fmt = libyuv::CanonicalFourCC(fourcc);
         frame_width = width;
         frame_height = height;
         fps_num = fps * 1000;
         fps_den = 1000;
-        buffer_argb.resize(width * height * 4);
-        buffer_output.resize(uyvy_frame_size(width, height));
+
+        uint32_t out_frame_size = uyvy_frame_size(width, height);
+
+        switch (frame_fmt) {
+            case libyuv::FOURCC_RAW:
+            case libyuv::FOURCC_24BG:
+                // RGB|BGR -> ARGB -> UYVY
+                buffer_tmp.resize(argb_frame_size(width, height));
+                buffer_output.resize(out_frame_size);
+                break;
+            case libyuv::FOURCC_I420:
+                // I420 -> UYVY
+                buffer_output.resize(out_frame_size);
+                break;
+            default:
+                throw std::runtime_error(
+                    "Unsupported image format, must RGB, BGR, or I420."
+                );
+        }
 
         mach_server = [[OBSDALMachServer alloc] init];
         BOOL started = [mach_server run];
@@ -80,7 +99,7 @@ class VirtualOutput {
         [NSThread sleepForTimeInterval:0.2f];
     }
 
-    void send(const uint8_t* rgb) {
+    void send(const uint8_t* frame) {
         if (mach_server == nil) {
             return;
         }
@@ -93,11 +112,21 @@ class VirtualOutput {
         
         uint64_t timestamp = mach_absolute_time();
 
-        uint8_t* argb = buffer_argb.data();
         uint8_t* uyvy = buffer_output.data();
-
-        rgb_to_argb(rgb, argb, frame_width, frame_height);
-        argb_to_uyvy(argb, uyvy, frame_width, frame_height);
+        
+        if (frame_fmt == libyuv::FOURCC_RAW) {
+            uint8_t* argb = buffer_tmp.data();
+            rgb_to_argb(frame, argb, frame_width, frame_height);
+            argb_to_uyvy(argb, uyvy, frame_width, frame_height);
+        } else if (frame_fmt == libyuv::FOURCC_24BG) {
+            uint8_t* argb = buffer_tmp.data();
+            bgr_to_argb(frame, argb, frame_width, frame_height);
+            argb_to_uyvy(argb, uyvy, frame_width, frame_height);
+        } else if (frame_fmt == libyuv::FOURCC_I420) {
+            i420_to_uyvy(frame, uyvy, frame_width, frame_height);
+        } else {
+            throw std::logic_error("not implemented");
+        }
 
         CGFloat width = frame_width;
         CGFloat height = frame_height;

--- a/pyvirtualcam/native_macos_obs/virtual_output.h
+++ b/pyvirtualcam/native_macos_obs/virtual_output.h
@@ -62,7 +62,8 @@ class VirtualOutput {
         switch (frame_fmt) {
             case libyuv::FOURCC_RAW:
             case libyuv::FOURCC_24BG:
-                // RGB|BGR -> ARGB -> UYVY
+            case libyuv::FOURCC_J400:
+                // RGB|BGR|GRAY -> ARGB -> UYVY
                 buffer_tmp.resize(argb_frame_size(width, height));
                 buffer_output.resize(out_frame_size);
                 break;
@@ -127,6 +128,10 @@ class VirtualOutput {
                 break;
             case libyuv::FOURCC_24BG:
                 bgr_to_argb(frame, tmp, frame_width, frame_height);
+                argb_to_uyvy(tmp, uyvy, frame_width, frame_height);
+                break;
+            case libyuv::FOURCC_J400:
+                gray_to_argb(frame, tmp, frame_width, frame_height);
                 argb_to_uyvy(tmp, uyvy, frame_width, frame_height);
                 break;
             case libyuv::FOURCC_I420:

--- a/pyvirtualcam/native_shared/image_formats.h
+++ b/pyvirtualcam/native_shared/image_formats.h
@@ -2,6 +2,7 @@
 
 #include <libyuv.h>
 
+// copy
 static void rgb_to_argb(const uint8_t *rgb, uint8_t* argb, uint32_t width, uint32_t height) {
     libyuv::RAWToARGB(
         rgb, width * 3,
@@ -9,6 +10,7 @@ static void rgb_to_argb(const uint8_t *rgb, uint8_t* argb, uint32_t width, uint3
         width, height);
 }
 
+// horizontal and vertical subsampling and yuv conversion
 static void rgb_to_i420(const uint8_t *rgb, uint8_t* i420, uint32_t width, uint32_t height) {
     uint32_t half_width = width / 2;
     uint32_t half_height = height / 2;
@@ -21,6 +23,7 @@ static void rgb_to_i420(const uint8_t *rgb, uint8_t* i420, uint32_t width, uint3
         width, height);
 }
 
+// copy
 static void bgr_to_argb(const uint8_t *bgr, uint8_t* argb, uint32_t width, uint32_t height) {
     libyuv::RGB24ToARGB(
         bgr, width * 3,
@@ -28,6 +31,7 @@ static void bgr_to_argb(const uint8_t *bgr, uint8_t* argb, uint32_t width, uint3
         width, height);
 }
 
+// horizontal and vertical subsampling and yuv conversion
 static void bgr_to_i420(const uint8_t *bgr, uint8_t* i420, uint32_t width, uint32_t height) {
     uint32_t half_width = width / 2;
     uint32_t half_height = height / 2;
@@ -40,6 +44,7 @@ static void bgr_to_i420(const uint8_t *bgr, uint8_t* i420, uint32_t width, uint3
         width, height);
 }
 
+// horizontal and vertical subsampling and yuv conversion
 static void argb_to_nv12(const uint8_t *argb, uint8_t* nv12, uint32_t width, uint32_t height) {
     libyuv::ARGBToNV12(
         argb, width * 4,
@@ -48,6 +53,7 @@ static void argb_to_nv12(const uint8_t *argb, uint8_t* nv12, uint32_t width, uin
         width, height);
 }
 
+// horizontal subsampling and yuv conversion
 static void argb_to_uyvy(const uint8_t *argb, uint8_t* uyvy, uint32_t width, uint32_t height) {
     libyuv::ARGBToUYVY(
         argb, width * 4,
@@ -55,6 +61,7 @@ static void argb_to_uyvy(const uint8_t *argb, uint8_t* uyvy, uint32_t width, uin
         width, height);
 }
 
+// copy
 static void i420_to_nv12(const uint8_t *i420, uint8_t* nv12, uint32_t width, uint32_t height) {
     uint32_t half_width = width / 2;
     uint32_t half_height = height / 2;
@@ -68,6 +75,7 @@ static void i420_to_nv12(const uint8_t *i420, uint8_t* nv12, uint32_t width, uin
         width, height);
 }
 
+// vertical upsampling
 static void i420_to_uyvy(const uint8_t *i420, uint8_t* uyvy, uint32_t width, uint32_t height) {
     uint32_t half_width = width / 2;
     uint32_t half_height = height / 2;
@@ -80,16 +88,63 @@ static void i420_to_uyvy(const uint8_t *i420, uint8_t* uyvy, uint32_t width, uin
         width, height);
 }
 
-static uint32_t argb_frame_size(uint32_t width, uint32_t height) {
-    return height * width * 4;
+// vertical subsampling
+static void yuyv_to_nv12(const uint8_t *yuyv, uint8_t* nv12, uint32_t width, uint32_t height) {
+    libyuv::YUY2ToNV12(
+        yuyv, width * 2,
+        nv12, width,
+        nv12 + width * height, width,
+        width, height);
 }
 
-static uint32_t uyvy_frame_size(uint32_t width, uint32_t height) {
-    return height * width * 2;
+// vertical subsampling
+static void yuyv_to_i420(const uint8_t *yuyv, uint8_t* i420, uint32_t width, uint32_t height) {
+    uint32_t half_width = width / 2;
+    uint32_t half_height = height / 2;
+
+    libyuv::YUY2ToI420(
+        yuyv, width * 2,
+        i420, width,
+        i420 + width * height, half_width,
+        i420 + width * height + half_width * half_height, half_width,
+        width, height);
+}
+
+// copy
+static void yuyv_to_i422(const uint8_t *yuyv, uint8_t* i422, uint32_t width, uint32_t height) {
+    uint32_t half_width = width / 2;
+
+    libyuv::YUY2ToI422(
+        yuyv, width * 2,
+        i422, width,
+        i422 + width * height, half_width,
+        i422 + width * height + half_width * height, half_width,
+        width, height);
+}
+
+// copy
+static void i422_to_uyvy(const uint8_t *i422, uint8_t* uyvy, uint32_t width, uint32_t height) {
+    uint32_t half_width = width / 2;
+
+    libyuv::I422ToUYVY(
+        i422, width,
+        i422 + width * height, half_width,
+        i422 + width * height + half_width * height, half_width,
+        uyvy, width * 2,
+        width, height);
+}
+
+static uint32_t argb_frame_size(uint32_t width, uint32_t height) {
+    return height * width * 4;
 }
 
 static uint32_t i420_frame_size(uint32_t width, uint32_t height) {
     return (width + width / 2) * height;
 }
 
+static uint32_t i422_frame_size(uint32_t width, uint32_t height) {
+    return height * width * 2;
+}
+
 #define nv12_frame_size i420_frame_size
+#define uyvy_frame_size i422_frame_size

--- a/pyvirtualcam/native_shared/image_formats.h
+++ b/pyvirtualcam/native_shared/image_formats.h
@@ -21,16 +21,22 @@ static void rgb_to_i420(const uint8_t *rgb, uint8_t* i420, uint32_t width, uint3
         width, height);
 }
 
-static void i420_to_nv12(const uint8_t *i420, uint8_t* nv12, uint32_t width, uint32_t height) {
+static void bgr_to_argb(const uint8_t *bgr, uint8_t* argb, uint32_t width, uint32_t height) {
+    libyuv::RGB24ToARGB(
+        bgr, width * 3,
+        argb, width * 4,
+        width, height);
+}
+
+static void bgr_to_i420(const uint8_t *bgr, uint8_t* i420, uint32_t width, uint32_t height) {
     uint32_t half_width = width / 2;
     uint32_t half_height = height / 2;
 
-    libyuv::I420ToNV12(
+    libyuv::RGB24ToI420(
+        bgr, width * 3,
         i420, width,
         i420 + width * height, half_width,
         i420 + width * height + half_width * half_height, half_width,
-        nv12, width,
-        nv12 + width * height, width,
         width, height);
 }
 
@@ -47,6 +53,35 @@ static void argb_to_uyvy(const uint8_t *argb, uint8_t* uyvy, uint32_t width, uin
         argb, width * 4,
         uyvy, width * 2,
         width, height);
+}
+
+static void i420_to_nv12(const uint8_t *i420, uint8_t* nv12, uint32_t width, uint32_t height) {
+    uint32_t half_width = width / 2;
+    uint32_t half_height = height / 2;
+
+    libyuv::I420ToNV12(
+        i420, width,
+        i420 + width * height, half_width,
+        i420 + width * height + half_width * half_height, half_width,
+        nv12, width,
+        nv12 + width * height, width,
+        width, height);
+}
+
+static void i420_to_uyvy(const uint8_t *i420, uint8_t* uyvy, uint32_t width, uint32_t height) {
+    uint32_t half_width = width / 2;
+    uint32_t half_height = height / 2;
+
+    libyuv::I420ToUYVY(
+        i420, width,
+        i420 + width * height, half_width,
+        i420 + width * height + half_width * half_height, half_width,
+        uyvy, width * 2,
+        width, height);
+}
+
+static uint32_t argb_frame_size(uint32_t width, uint32_t height) {
+    return height * width * 4;
 }
 
 static uint32_t uyvy_frame_size(uint32_t width, uint32_t height) {

--- a/pyvirtualcam/native_shared/image_formats.h
+++ b/pyvirtualcam/native_shared/image_formats.h
@@ -3,6 +3,14 @@
 #include <libyuv.h>
 
 // copy
+static void gray_to_argb(const uint8_t *gray, uint8_t* argb, uint32_t width, uint32_t height) {
+    libyuv::J400ToARGB(
+        gray, width,
+        argb, width * 4,
+        width, height);
+}
+
+// copy
 static void rgb_to_argb(const uint8_t *rgb, uint8_t* argb, uint32_t width, uint32_t height) {
     libyuv::RAWToARGB(
         rgb, width * 3,

--- a/pyvirtualcam/native_windows_obs/main.cpp
+++ b/pyvirtualcam/native_windows_obs/main.cpp
@@ -10,8 +10,8 @@ class Camera {
     VirtualOutput virtual_output;
 
   public:
-    Camera(uint32_t width, uint32_t height, double fps)
-     : virtual_output {width, height, fps} {
+    Camera(uint32_t width, uint32_t height, double fps, uint32_t fourcc)
+     : virtual_output {width, height, fps, fourcc} {
     }
 
     void close() {
@@ -30,8 +30,9 @@ class Camera {
 
 PYBIND11_MODULE(_native_windows_obs, m) {
     py::class_<Camera>(m, "Camera")
-        .def(py::init<uint32_t, uint32_t, double>(),
-             py::arg("width"), py::arg("height"), py::arg("fps"))
+        .def(py::init<uint32_t, uint32_t, double, uint32_t>(),
+             py::arg("width"), py::arg("height"), py::arg("fps"),
+             py::kw_only(), py::arg("fmt"))
         .def("close", &Camera::close)    
         .def("send", &Camera::send)
         .def("device", &Camera::device);

--- a/pyvirtualcam/native_windows_obs/virtual_output.h
+++ b/pyvirtualcam/native_windows_obs/virtual_output.h
@@ -60,7 +60,8 @@ class VirtualOutput {
                 buffer_output.resize(out_frame_size);
                 break;
             case libyuv::FOURCC_I420:
-                // I420 -> NV12
+            case libyuv::FOURCC_YUY2:
+                // I420|YUYV -> NV12
                 buffer_output.resize(out_frame_size);
                 break;
             default:
@@ -96,18 +97,25 @@ class VirtualOutput {
 
         uint8_t* nv12 = buffer_output.data();
         
-        if (frame_fmt == libyuv::FOURCC_RAW) {
-            uint8_t* i420 = buffer_tmp.data();
-            rgb_to_i420(frame, i420, frame_width, frame_height);
-            i420_to_nv12(i420, nv12, frame_width, frame_height);
-        } else if (frame_fmt == libyuv::FOURCC_24BG) {
-            uint8_t* i420 = buffer_tmp.data();
-            bgr_to_i420(frame, i420, frame_width, frame_height);
-            i420_to_nv12(i420, nv12, frame_width, frame_height);
-        } else if (frame_fmt == libyuv::FOURCC_I420) {
-            i420_to_nv12(frame, nv12, frame_width, frame_height);
-        } else {
-            throw std::logic_error("not implemented");
+        switch (frame_fmt) {
+            case libyuv::FOURCC_RAW:
+                uint8_t* i420 = buffer_tmp.data();
+                rgb_to_i420(frame, i420, frame_width, frame_height);
+                i420_to_nv12(i420, nv12, frame_width, frame_height);
+                break;
+            case libyuv::FOURCC_24BG:
+                uint8_t* i420 = buffer_tmp.data();
+                bgr_to_i420(frame, i420, frame_width, frame_height);
+                i420_to_nv12(i420, nv12, frame_width, frame_height);
+                break;
+            case libyuv::FOURCC_I420:
+                i420_to_nv12(frame, nv12, frame_width, frame_height);
+                break;
+            case libyuv::FOURCC_YUY2:
+                yuyv_to_nv12(frame, nv12, frame_width, frame_height);
+                break;
+            default:
+                throw std::logic_error("not implemented");
         }
 
         // NV12 has two planes

--- a/pyvirtualcam/native_windows_obs/virtual_output.h
+++ b/pyvirtualcam/native_windows_obs/virtual_output.h
@@ -59,6 +59,11 @@ class VirtualOutput {
                 buffer_tmp.resize(i420_frame_size(width, height));
                 buffer_output.resize(out_frame_size);
                 break;
+            case libyuv::FOURCC_J400:
+                // GRAY -> ARGB -> NV12
+                buffer_tmp.resize(argb_frame_size(width, height));
+                buffer_output.resize(out_frame_size);
+                break;
             case libyuv::FOURCC_I420:
             case libyuv::FOURCC_YUY2:
                 // I420|YUYV -> NV12
@@ -106,6 +111,10 @@ class VirtualOutput {
             case libyuv::FOURCC_24BG:
                 bgr_to_i420(frame, tmp, frame_width, frame_height);
                 i420_to_nv12(tmp, nv12, frame_width, frame_height);
+                break;
+            case libyuv::FOURCC_J400:
+                gray_to_argb(frame, tmp, frame_width, frame_height);
+                argb_to_nv12(tmp, nv12, frame_width, frame_height);
                 break;
             case libyuv::FOURCC_I420:
                 i420_to_nv12(frame, nv12, frame_width, frame_height);

--- a/pyvirtualcam/native_windows_obs/virtual_output.h
+++ b/pyvirtualcam/native_windows_obs/virtual_output.h
@@ -12,7 +12,8 @@ class VirtualOutput {
     video_queue_t *vq;
     uint32_t frame_width;
     uint32_t frame_height;
-    std::vector<uint8_t> buffer_i420;
+    uint32_t frame_fmt;
+    std::vector<uint8_t> buffer_tmp;
     std::vector<uint8_t> buffer_output;
     bool have_clockfreq = false;
     LARGE_INTEGER clock_freq;
@@ -34,7 +35,7 @@ class VirtualOutput {
     }
 
   public:
-    VirtualOutput(uint32_t width, uint32_t height, double fps) {
+    VirtualOutput(uint32_t width, uint32_t height, double fps, uint32_t fourcc) {
         // https://github.com/obsproject/obs-studio/blob/9da6fc67/.github/workflows/main.yml#L484
         LPCWSTR guid = L"CLSID\\{A3FCE0F5-3493-419F-958A-ABA1250EC20B}";
         HKEY key = nullptr;
@@ -45,6 +46,29 @@ class VirtualOutput {
             );
         }
 
+        frame_fmt = libyuv::CanonicalFourCC(fourcc);
+        frame_width = width;
+        frame_height = height;
+
+        uint32_t out_frame_size = nv12_frame_size(width, height);
+
+        switch (frame_fmt) {
+            case libyuv::FOURCC_RAW:
+            case libyuv::FOURCC_24BG:
+                // RGB|BGR -> I420 -> NV12
+                buffer_tmp.resize(i420_frame_size(width, height));
+                buffer_output.resize(out_frame_size);
+                break;
+            case libyuv::FOURCC_I420:
+                // I420 -> NV12
+                buffer_output.resize(out_frame_size);
+                break;
+            default:
+                throw std::runtime_error(
+                    "Unsupported image format, must RGB, BGR, or I420."
+                );
+        }
+        
         uint64_t interval = (uint64_t)(10000000.0 / fps);
 
         vq = video_queue_create(width, height, interval);
@@ -53,10 +77,6 @@ class VirtualOutput {
             throw std::runtime_error("virtual camera output could not be started");
         }
 
-        frame_width = width;
-        frame_height = height;
-        buffer_i420.resize(i420_frame_size(width, height));
-        buffer_output.resize(nv12_frame_size(width, height));
         output_running = true;
     }
 
@@ -69,18 +89,26 @@ class VirtualOutput {
         output_running = false;
     }
 
-    // data is in RGB format (packed RGB, 24bpp, RGBRGB...)
-    // queue expects NV12 (semi-planar YUV, 12bpp)
-    void send(const uint8_t *rgb)
+    void send(const uint8_t *frame)
     {
         if (!output_running)
             return;
 
-        uint8_t* i420 = buffer_i420.data();
         uint8_t* nv12 = buffer_output.data();
-
-        rgb_to_i420(rgb, i420, frame_width, frame_height);
-        i420_to_nv12(i420, nv12, frame_width, frame_height);
+        
+        if (frame_fmt == libyuv::FOURCC_RAW) {
+            uint8_t* i420 = buffer_tmp.data();
+            rgb_to_i420(frame, i420, frame_width, frame_height);
+            i420_to_nv12(i420, nv12, frame_width, frame_height);
+        } else if (frame_fmt == libyuv::FOURCC_24BG) {
+            uint8_t* i420 = buffer_tmp.data();
+            bgr_to_i420(frame, i420, frame_width, frame_height);
+            i420_to_nv12(i420, nv12, frame_width, frame_height);
+        } else if (frame_fmt == libyuv::FOURCC_I420) {
+            i420_to_nv12(frame, nv12, frame_width, frame_height);
+        } else {
+            throw std::logic_error("not implemented");
+        }
 
         // NV12 has two planes
         uint8_t* y = nv12;

--- a/pyvirtualcam/native_windows_obs/virtual_output.h
+++ b/pyvirtualcam/native_windows_obs/virtual_output.h
@@ -95,18 +95,17 @@ class VirtualOutput {
         if (!output_running)
             return;
 
+        uint8_t* tmp = buffer_tmp.data();
         uint8_t* nv12 = buffer_output.data();
         
         switch (frame_fmt) {
             case libyuv::FOURCC_RAW:
-                uint8_t* i420 = buffer_tmp.data();
-                rgb_to_i420(frame, i420, frame_width, frame_height);
-                i420_to_nv12(i420, nv12, frame_width, frame_height);
+                rgb_to_i420(frame, tmp, frame_width, frame_height);
+                i420_to_nv12(tmp, nv12, frame_width, frame_height);
                 break;
             case libyuv::FOURCC_24BG:
-                uint8_t* i420 = buffer_tmp.data();
-                bgr_to_i420(frame, i420, frame_width, frame_height);
-                i420_to_nv12(i420, nv12, frame_width, frame_height);
+                bgr_to_i420(frame, tmp, frame_width, frame_height);
+                i420_to_nv12(tmp, nv12, frame_width, frame_height);
                 break;
             case libyuv::FOURCC_I420:
                 i420_to_nv12(frame, nv12, frame_width, frame_height);

--- a/pyvirtualcam/util.py
+++ b/pyvirtualcam/util.py
@@ -23,3 +23,9 @@ class FPSCounter(object):
     @property
     def avg_fps(self):
         return 1 / self.avg_delta
+
+
+def fourcc(s: str) -> int:
+    if len(s) != 4:
+        raise ValueError('fourcc must be 4 characters')
+    return ord(s[0]) | (ord(s[1]) << 8) | (ord(s[2]) << 16) | (ord(s[3]) << 24)

--- a/samples/video.py
+++ b/samples/video.py
@@ -2,6 +2,7 @@
 
 import argparse
 import pyvirtualcam
+from pyvirtualcam import PixelFormat
 import cv2
 
 parser = argparse.ArgumentParser()
@@ -17,7 +18,7 @@ width = int(video.get(cv2.CAP_PROP_FRAME_WIDTH))
 height = int(video.get(cv2.CAP_PROP_FRAME_HEIGHT))
 fps = video.get(cv2.CAP_PROP_FPS)
 
-with pyvirtualcam.Camera(width=width, height=height, fps=fps, print_fps=args.fps) as cam:
+with pyvirtualcam.Camera(width, height, fps, fmt=PixelFormat.BGR, print_fps=args.fps) as cam:
     print(f'Virtual cam started: {cam.device} ({cam.width}x{cam.height} @ {cam.fps}fps)')
     count = 0
     while True:
@@ -31,9 +32,6 @@ with pyvirtualcam.Camera(width=width, height=height, fps=fps, print_fps=args.fps
         if not ret:
             raise RuntimeError('Error fetching frame')
         
-        # Convert to RGB.
-        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-
         # Send to virtual cam.
         cam.send(frame)
 

--- a/samples/webcam_filter.py
+++ b/samples/webcam_filter.py
@@ -4,6 +4,7 @@
 import argparse
 import cv2
 import pyvirtualcam
+from pyvirtualcam import PixelFormat
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--camera", type=int, default=0, help="ID of webcam device (default: 0)")
@@ -32,7 +33,7 @@ print(f'Webcam capture started ({width}x{height} @ {fps_in}fps)')
 fps_out = 20
 
 try:
-    with pyvirtualcam.Camera(width, height, fps_out, print_fps=args.fps) as cam:
+    with pyvirtualcam.Camera(width, height, fps_out, fmt=PixelFormat.BGR, print_fps=args.fps) as cam:
         print(f'Virtual cam started: {cam.device} ({cam.width}x{cam.height} @ {cam.fps}fps)')
 
         # Shake two channels horizontally each frame.
@@ -49,9 +50,6 @@ try:
             c1, c2 = channels[cam.frames_sent % 3]
             frame[:,:-dx,c1] = frame[:,dx:,c1]
             frame[:,dx:,c2] = frame[:,:-dx,c2]
-
-            # Convert to RGB.
-            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
 
             # Send to virtual cam.
             cam.send(frame)

--- a/test/test_camera.py
+++ b/test/test_camera.py
@@ -58,7 +58,7 @@ def test_invalid_frame_dtype():
 
 def test_alternative_pixel_formats():
     with pyvirtualcam.Camera(width=1280, height=720, fps=20, fmt=PixelFormat.BGR) as cam:
-        cam.send(np.zeros((cam.width, cam.height, 3), np.uint8))
+        cam.send(np.zeros((cam.height, cam.width, 3), np.uint8))
 
     with pyvirtualcam.Camera(width=1280, height=720, fps=20, fmt=PixelFormat.I420) as cam:
         cam.send(np.zeros(cam.height * cam.width + cam.height * (cam.width // 2), np.uint8))

--- a/test/test_camera.py
+++ b/test/test_camera.py
@@ -1,9 +1,9 @@
 import os
 import platform
-import warnings
 import pytest
 import numpy as np
 import pyvirtualcam
+from pyvirtualcam import PixelFormat
 
 def test_consecutive():
     with pyvirtualcam.Camera(width=1280, height=720, fps=20) as cam:
@@ -50,6 +50,21 @@ def test_invalid_frame_shape():
             cam.send(np.zeros((cam.height, cam.width, 1), np.uint8))
         with pytest.raises(ValueError):
             cam.send(np.zeros((cam.height, cam.width), np.uint8))
+
+def test_invalid_frame_dtype():
+    with pyvirtualcam.Camera(width=1280, height=720, fps=20) as cam:
+        with pytest.raises(TypeError):
+            cam.send(np.zeros((cam.height, cam.width, 3), np.uint16))
+
+def test_alternative_pixel_formats():
+    with pyvirtualcam.Camera(width=1280, height=720, fps=20, fmt=PixelFormat.BGR) as cam:
+        cam.send(np.zeros((cam.width, cam.height, 3), np.uint8))
+
+    with pyvirtualcam.Camera(width=1280, height=720, fps=20, fmt=PixelFormat.I420) as cam:
+        cam.send(np.zeros(cam.height * cam.width + cam.height * (cam.width // 2), np.uint8))
+    
+    with pyvirtualcam.Camera(width=1280, height=720, fps=20, fmt=PixelFormat.YUYV) as cam:
+        cam.send(np.zeros(cam.height * cam.width * 2, np.uint8))
 
 @pytest.mark.skipif(
     os.environ.get('CI') and platform.system() == 'Darwin',

--- a/test/test_camera.py
+++ b/test/test_camera.py
@@ -59,6 +59,9 @@ def test_invalid_frame_dtype():
 def test_alternative_pixel_formats():
     with pyvirtualcam.Camera(width=1280, height=720, fps=20, fmt=PixelFormat.BGR) as cam:
         cam.send(np.zeros((cam.height, cam.width, 3), np.uint8))
+    
+    with pyvirtualcam.Camera(width=1280, height=720, fps=20, fmt=PixelFormat.GRAY) as cam:
+        cam.send(np.zeros((cam.height, cam.width), np.uint8))
 
     with pyvirtualcam.Camera(width=1280, height=720, fps=20, fmt=PixelFormat.I420) as cam:
         cam.send(np.zeros(cam.height * cam.width + cam.height * (cam.width // 2), np.uint8))

--- a/test/test_camera.py
+++ b/test/test_camera.py
@@ -51,13 +51,6 @@ def test_invalid_frame_shape():
         with pytest.raises(ValueError):
             cam.send(np.zeros((cam.height, cam.width), np.uint8))
 
-def test_deprecated_rgba_frame_format():
-    with pyvirtualcam.Camera(width=1280, height=720, fps=20) as cam:
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            with pytest.raises(DeprecationWarning):
-                cam.send(np.zeros((cam.height, cam.width, 4), np.uint8))
-
 @pytest.mark.skipif(
     os.environ.get('CI') and platform.system() == 'Darwin',
     reason='disabled due to high fluctuations in CI, manually verified on MacBook Pro')


### PR DESCRIPTION
This adds support for additional pixel formats in addition to RGB:
- BGR (useful for OpenCV)
- GRAY
- I420
- YUYV

Support for RGBA has been removed to keep the code clean.

@FredericDlugi fyi, is this what you had in mind?