### PR TITLE
NV12 & UYVY support, Camera.native_fmt, fix for GRAY & YUYV on Linux

### DIFF
--- a/pyvirtualcam/native_linux_v4l2loopback/main.cpp
+++ b/pyvirtualcam/native_linux_v4l2loopback/main.cpp
@@ -22,6 +22,10 @@ class Camera {
         return virtual_output.device();
     }
 
+    uint32_t native_fourcc() {
+        return virtual_output.native_fourcc();
+    }
+
     void send(py::array_t<uint8_t, py::array::c_style> frame) {
         py::buffer_info buf = frame.request();    
         virtual_output.send(static_cast<uint8_t*>(buf.ptr));
@@ -32,8 +36,9 @@ PYBIND11_MODULE(_native_linux_v4l2loopback, m) {
     py::class_<Camera>(m, "Camera")
         .def(py::init<uint32_t, uint32_t, double, uint32_t>(),
              py::arg("width"), py::arg("height"), py::arg("fps"),
-             py::kw_only(), py::arg("fmt"))
+             py::kw_only(), py::arg("fourcc"))
         .def("close", &Camera::close)
         .def("send", &Camera::send)
-        .def("device", &Camera::device);
+        .def("device", &Camera::device)
+        .def("native_fourcc", &Camera::native_fourcc);
 }

--- a/pyvirtualcam/native_macos_obs/main.mm
+++ b/pyvirtualcam/native_macos_obs/main.mm
@@ -24,6 +24,10 @@ class Camera {
         return virtual_output.device();
     }
 
+    uint32_t native_fourcc() {
+        return virtual_output.native_fourcc();
+    }
+
     void send(py::array_t<uint8_t, py::array::c_style> frame) {
         py::buffer_info buf = frame.request();    
         virtual_output.send(static_cast<uint8_t*>(buf.ptr));
@@ -34,8 +38,9 @@ PYBIND11_MODULE(_native_macos_obs, m) {
     py::class_<Camera>(m, "Camera")
         .def(py::init<uint32_t, uint32_t, double, uint32_t>(),
              py::arg("width"), py::arg("height"), py::arg("fps"),
-             py::kw_only(), py::arg("fmt"))
+             py::kw_only(), py::arg("fourcc"))
         .def("close", &Camera::close)
         .def("send", &Camera::send)
-        .def("device", &Camera::device);
+        .def("device", &Camera::device)
+        .def("native_fourcc", &Camera::native_fourcc);
 }

--- a/pyvirtualcam/native_shared/image_formats.h
+++ b/pyvirtualcam/native_shared/image_formats.h
@@ -83,6 +83,20 @@ static void i420_to_nv12(const uint8_t *i420, uint8_t* nv12, uint32_t width, uin
         width, height);
 }
 
+// copy
+static void nv12_to_i420(const uint8_t *nv12, uint8_t* i420, uint32_t width, uint32_t height) {
+    uint32_t half_width = width / 2;
+    uint32_t half_height = height / 2;
+
+    libyuv::NV12ToI420(
+        nv12, width,
+        nv12 + width * height, width,
+        i420, width,
+        i420 + width * height, half_width,
+        i420 + width * height + half_width * half_height, half_width,
+        width, height);
+}
+
 // vertical upsampling
 static void i420_to_uyvy(const uint8_t *i420, uint8_t* uyvy, uint32_t width, uint32_t height) {
     uint32_t half_width = width / 2;
@@ -130,6 +144,15 @@ static void yuyv_to_i422(const uint8_t *yuyv, uint8_t* i422, uint32_t width, uin
         width, height);
 }
 
+// vertical subsampling
+static void uyvy_to_nv12(const uint8_t *uyvy, uint8_t* nv12, uint32_t width, uint32_t height) {
+    libyuv::UYVYToNV12(
+        uyvy, width * 2,
+        nv12, width,
+        nv12 + width * height, width,
+        width, height);
+}
+
 // copy
 static void i422_to_uyvy(const uint8_t *i422, uint8_t* uyvy, uint32_t width, uint32_t height) {
     uint32_t half_width = width / 2;
@@ -146,6 +169,10 @@ static uint32_t argb_frame_size(uint32_t width, uint32_t height) {
     return height * width * 4;
 }
 
+static uint32_t gray_frame_size(uint32_t width, uint32_t height) {
+    return width + width;
+}
+
 static uint32_t i420_frame_size(uint32_t width, uint32_t height) {
     return (width + width / 2) * height;
 }
@@ -156,3 +183,4 @@ static uint32_t i422_frame_size(uint32_t width, uint32_t height) {
 
 #define nv12_frame_size i420_frame_size
 #define uyvy_frame_size i422_frame_size
+#define yuyv_frame_size i422_frame_size

--- a/pyvirtualcam/native_windows_obs/main.cpp
+++ b/pyvirtualcam/native_windows_obs/main.cpp
@@ -22,6 +22,10 @@ class Camera {
         return virtual_output.device();
     }
 
+    uint32_t native_fourcc() {
+        return virtual_output.native_fourcc();
+    }
+
     void send(py::array_t<uint8_t, py::array::c_style> frame) {
         py::buffer_info buf = frame.request();    
         virtual_output.send(static_cast<uint8_t*>(buf.ptr));
@@ -32,8 +36,9 @@ PYBIND11_MODULE(_native_windows_obs, m) {
     py::class_<Camera>(m, "Camera")
         .def(py::init<uint32_t, uint32_t, double, uint32_t>(),
              py::arg("width"), py::arg("height"), py::arg("fps"),
-             py::kw_only(), py::arg("fmt"))
-        .def("close", &Camera::close)    
+             py::kw_only(), py::arg("fourcc"))
+        .def("close", &Camera::close)
         .def("send", &Camera::send)
-        .def("device", &Camera::device);
+        .def("device", &Camera::device)
+        .def("native_fourcc", &Camera::native_fourcc);
 }

--- a/pyvirtualcam/util.py
+++ b/pyvirtualcam/util.py
@@ -25,7 +25,10 @@ class FPSCounter(object):
         return 1 / self.avg_delta
 
 
-def fourcc(s: str) -> int:
+def encode_fourcc(s: str) -> int:
     if len(s) != 4:
         raise ValueError('fourcc must be 4 characters')
     return ord(s[0]) | (ord(s[1]) << 8) | (ord(s[2]) << 16) | (ord(s[3]) << 24)
+
+def decode_fourcc(i: int) -> str:
+    return chr((i & 0xff)) + chr((i >> 8) & 0xff) + chr((i >> 16) & 0xff) + chr((i >> 24) & 0xff)

--- a/test/test_camera.py
+++ b/test/test_camera.py
@@ -56,17 +56,39 @@ def test_invalid_frame_dtype():
         with pytest.raises(TypeError):
             cam.send(np.zeros((cam.height, cam.width, 3), np.uint16))
 
+EXPECTED_NATIVE_FMTS = {
+    'Windows': lambda _: PixelFormat.NV12,
+    'Darwin': lambda _: PixelFormat.UYVY,
+    'Linux': lambda fmt: PixelFormat.I420 if fmt in [PixelFormat.RGB, PixelFormat.BGR]
+                         else fmt,
+}
+
 def test_alternative_pixel_formats():
+    def check_native_fmt(cam):
+        assert cam.native_fmt == EXPECTED_NATIVE_FMTS[platform.system()](cam.fmt)
+    
     with pyvirtualcam.Camera(width=1280, height=720, fps=20, fmt=PixelFormat.BGR) as cam:
+        check_native_fmt(cam)
         cam.send(np.zeros((cam.height, cam.width, 3), np.uint8))
     
     with pyvirtualcam.Camera(width=1280, height=720, fps=20, fmt=PixelFormat.GRAY) as cam:
+        check_native_fmt(cam)
         cam.send(np.zeros((cam.height, cam.width), np.uint8))
 
     with pyvirtualcam.Camera(width=1280, height=720, fps=20, fmt=PixelFormat.I420) as cam:
+        check_native_fmt(cam)
+        cam.send(np.zeros(cam.height * cam.width + cam.height * (cam.width // 2), np.uint8))
+
+    with pyvirtualcam.Camera(width=1280, height=720, fps=20, fmt=PixelFormat.NV12) as cam:
+        check_native_fmt(cam)
         cam.send(np.zeros(cam.height * cam.width + cam.height * (cam.width // 2), np.uint8))
     
     with pyvirtualcam.Camera(width=1280, height=720, fps=20, fmt=PixelFormat.YUYV) as cam:
+        check_native_fmt(cam)
+        cam.send(np.zeros(cam.height * cam.width * 2, np.uint8))
+    
+    with pyvirtualcam.Camera(width=1280, height=720, fps=20, fmt=PixelFormat.UYVY) as cam:
+        check_native_fmt(cam)
         cam.send(np.zeros(cam.height * cam.width * 2, np.uint8))
 
 @pytest.mark.skipif(


### PR DESCRIPTION
NV12 & UYVY was added to allow pass-through (without internal conversions) on all backends (in case someone has the need for it), which previously was only possible on Linux. NV12 is the native format on the OBS Windows backend, and UYVY on the OBS macOS backend. The Linux backend has multiple native formats (GRAY, I420, NV12, YUYV, UYVY).