### PR TITLE
CI: fix macOS test failure due to OpenCV update

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 # test dependencies
 pytest
-opencv-python
+opencv-python==4.5.1
 imageio
 
 # documentation dependencies

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 # test dependencies
 pytest
-opencv-python==4.5.1
+opencv-python==4.5.1.48
 imageio
 
 # documentation dependencies


### PR DESCRIPTION
Working: https://github.com/letmaik/pyvirtualcam/runs/2486120864?check_suite_focus=true

Broken: https://github.com/letmaik/pyvirtualcam/runs/2559861604?check_suite_focus=true
```
OpenCV: not authorized to capture video (status 0), requesting...
OpenCV: camera failed to properly initialize!
```

The opencv-python versions between both builds are 4.5.1.48 and 4.5.2.52.

This PR temporarily pins OpenCV to the old version until OpenCV is fixed. I opened an issue here: https://github.com/opencv/opencv/issues/20094