### PR TITLE
Add AkVCam backend

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pyvirtualcam
 
-with pyvirtualcam.Camera(width=1280, height=720, fps=20, print_fps=True) as cam:
+with pyvirtualcam.Camera(width=3840, height=2160, fps=30, print_fps=True,backend="akvcam") as cam:
     print(f'Using virtual camera: {cam.device}')
     frame = np.zeros((cam.height, cam.width, 3), np.uint8)  # RGB
     while True:

--- a/pyvirtualcam/camera.py
+++ b/pyvirtualcam/camera.py
@@ -105,9 +105,10 @@ def register_backend(name: str, clazz):
     BACKENDS[name] = clazz
 
 if platform.system() == 'Windows':
-    from pyvirtualcam import _native_windows_obs, _native_windows_unity_capture
+    from pyvirtualcam import _native_windows_obs, _native_windows_unity_capture, _native_windows_akvcam
     register_backend('obs', _native_windows_obs.Camera)
     register_backend('unitycapture', _native_windows_unity_capture.Camera)
+    register_backend('akvcam', _native_windows_akvcam.Camera)
 elif platform.system() == 'Darwin':
     from pyvirtualcam import _native_macos_obs
     register_backend('obs', _native_macos_obs.Camera)

--- a/pyvirtualcam/native_windows_akvcam/main.cpp
+++ b/pyvirtualcam/native_windows_akvcam/main.cpp
@@ -1,0 +1,47 @@
+#include <stdexcept>
+#include <optional>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+#include "virtual_output.h"
+
+namespace py = pybind11;
+
+class AkVCamera {
+  private:
+    VirtualOutput virtual_output;
+
+  public:
+    AkVCamera(uint32_t width, uint32_t height, double fps, uint32_t fourcc, std::optional<std::string> device) 
+        : virtual_output {width, height, fps, fourcc, device} {
+    }
+
+    void close() {
+        virtual_output.stop();
+    }
+
+    std::string device() {
+        return virtual_output.device();
+    }
+
+    uint32_t native_fourcc() {
+        return virtual_output.native_fourcc();
+    }
+
+    void send(py::array_t<uint8_t, py::array::c_style> frame) {
+        py::buffer_info buf = frame.request();
+        virtual_output.send(static_cast<uint8_t*>(buf.ptr));
+    }
+};
+
+PYBIND11_MODULE(_native_windows_akvcam, m) {
+    py::class_<AkVCamera>(m, "Camera")
+        .def(py::init<uint32_t, uint32_t, double, uint32_t, std::optional<std::string>>(),
+             py::kw_only(),
+             py::arg("width"), py::arg("height"), py::arg("fps"),
+             py::arg("fourcc"), py::arg("device"))
+        .def("close", &AkVCamera::close)
+        .def("send", &AkVCamera::send)
+        .def("device", &AkVCamera::device)
+        .def("native_fourcc", &AkVCamera::native_fourcc);
+}

--- a/pyvirtualcam/native_windows_akvcam/virtual_output.h
+++ b/pyvirtualcam/native_windows_akvcam/virtual_output.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <windows.h>
+#include <vector>
+#include "../native_shared/image_formats.h"
+
+class VirtualOutput {
+  private:
+    std::string _device_name;
+
+    bool getDwordRegistry(HKEY key, std::string subkey, std::string valueName, int& data){
+        DWORD dataSize = sizeof(data);
+
+        if (RegGetValueA(
+            key, 
+            subkey.c_str(),
+            valueName.c_str(), 
+            RRF_RT_REG_DWORD, 
+            nullptr,
+            &data,
+            &dataSize) != ERROR_SUCCESS){
+                return false;
+            }
+
+        return true; 
+    }
+
+    bool getStringRegistry(HKEY key, std::string subkey, std::string valueName, std::string& data){
+        DWORD dataSize = sizeof(data);
+        HRESULT hr;
+
+        hr = RegGetValueA(key, subkey.c_str(), valueName.c_str(), RRF_RT_REG_SZ, nullptr, nullptr, &dataSize);
+        
+        if (hr != ERROR_SUCCESS){
+            return false;
+        }
+
+        data.resize(dataSize);
+
+        hr = RegGetValueA(key, subkey.c_str(), valueName.c_str(), RRF_RT_REG_SZ, nullptr, data.data(), &dataSize);
+
+        if (hr != ERROR_SUCCESS){
+            return false;
+        }
+        
+        return true; 
+    }
+
+  public:
+    VirtualOutput(uint32_t width, uint32_t height, double fps, uint32_t fourcc, std::optional<std::string> device) {
+        int number_cameras;
+        
+        //Get number of cameras available
+        if(!getDwordRegistry(HKEY_LOCAL_MACHINE, "SOFTWARE\\Webcamoid\\VirtualCamera\\Cameras","size",number_cameras)){
+            throw std::runtime_error("Unable to get number of available cameras");
+        }
+
+        //Get names of cameras available
+        std::string cameraDescription;
+        for(int i = 1; i <= number_cameras; i++){
+            if(!getStringRegistry(HKEY_LOCAL_MACHINE, "SOFTWARE\\Webcamoid\\VirtualCamera\\Cameras\\" + std::to_string(i),"description", cameraDescription)){
+                throw std::runtime_error("Unable to get camera " + std::to_string(i) + " description.");
+            }
+            std::cout<<cameraDescription << std::endl;
+        }
+
+    }
+
+    void stop()
+    {
+
+    }
+
+    void send(const uint8_t *frame)
+    {
+       
+    }
+
+    std::string device()
+    {
+        return _device_name;
+    }
+
+    uint32_t native_fourcc() {
+        return libyuv::FOURCC_YUY2;
+    }
+};

--- a/pyvirtualcam/native_windows_akvcam/virtual_output.h
+++ b/pyvirtualcam/native_windows_akvcam/virtual_output.h
@@ -176,7 +176,7 @@ class VirtualOutput {
         }
 
         // Allocate the frame buffer.
-        _buffer_size = 3 * _width;
+        _buffer_size = 3 * _width*_height;
         _buffer.resize(_buffer_size);
 
         ACTIVE_DEVICES.insert(_camera_info->desc);
@@ -210,14 +210,9 @@ class VirtualOutput {
         if (processState == WAIT_OBJECT_0){
             throw std::runtime_error("AkVCam stream process not running.");
         }
-
-       for (uint32_t y = 0; y < _height; y++) {
-            for (size_t byte = 0; byte < _buffer_size; byte++)
-                _buffer[byte] = frame[0,0] & 0xff;
-
-            DWORD bytesWritten = 0;
-            WriteFile(stream_proc.stdinWritePipe, _buffer.data(),DWORD(_buffer_size),&bytesWritten,NULL);
-        }
+      
+        DWORD bytesWritten = 0;
+        WriteFile(stream_proc.stdinWritePipe, frame,DWORD(_buffer_size),&bytesWritten,NULL);
     }
 
     std::string device()

--- a/pyvirtualcam/native_windows_akvcam/virtual_output.h
+++ b/pyvirtualcam/native_windows_akvcam/virtual_output.h
@@ -3,12 +3,36 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <windows.h>
-#include <vector>
+#include <map>
 #include "../native_shared/image_formats.h"
+
+struct StreamProcess{
+    HANDLE stdinReadPipe;
+    HANDLE stdinWritePipe;
+    SECURITY_ATTRIBUTES pipeAttributes;
+    STARTUPINFOA startupInfo;
+    PROCESS_INFORMATION procInfo;
+};
+
+struct CameraInfo {
+    std::string desc;
+    std::string id;
+};
+
+static std::set<std::string> ACTIVE_DEVICES;
 
 class VirtualOutput {
   private:
+    char * buffer;
     std::string _device_name;
+    std::optional<CameraInfo> _camera_info;
+    uint32_t _width;
+    uint32_t _height;
+    uint32_t _fourcc;
+
+    bool _running = false;
+
+    StreamProcess stream_proc;
 
     bool getDwordRegistry(HKEY key, std::string subkey, std::string valueName, int& data){
         DWORD dataSize = sizeof(data);
@@ -50,55 +74,152 @@ class VirtualOutput {
 
   public:
     VirtualOutput(uint32_t width, uint32_t height, double fps, uint32_t fourcc, std::optional<std::string> device) {
+
         int number_cameras;
-        
+        std::cout<<" enter" <<std::endl;
         //Get number of cameras available
         if(!getDwordRegistry(HKEY_LOCAL_MACHINE, "SOFTWARE\\Webcamoid\\VirtualCamera\\Cameras","size",number_cameras)){
             throw std::runtime_error("Unable to get number of available cameras");
         }
-
-        //Get names of cameras available
-        std::string cameraDescription;
-        for(int i = 1; i <= number_cameras; i++){
-            if(!getStringRegistry(HKEY_LOCAL_MACHINE, "SOFTWARE\\Webcamoid\\VirtualCamera\\Cameras\\" + std::to_string(i),"description", cameraDescription)){
-                throw std::runtime_error("Unable to get camera " + std::to_string(i) + " description.");
-            }
-            std::cout<<cameraDescription << std::endl;
-
-            int cameraFormats;
-            if(!getDwordRegistry(HKEY_LOCAL_MACHINE, "SOFTWARE\\Webcamoid\\VirtualCamera\\Cameras\\" + std::to_string(i) + "\\Formats","size", cameraFormats)){
-                throw std::runtime_error("Unable to get number camera formats");
-            }
-
-            int width;
-            int height;
-            for(int j = 1; j <= cameraFormats; j++){
-
-                std::cout<< "Format #" << std::to_string(j) << ":" << std::endl;
-                if(!getDwordRegistry(HKEY_LOCAL_MACHINE, "SOFTWARE\\Webcamoid\\VirtualCamera\\Cameras\\" + std::to_string(i) + "\\Formats\\" + std::to_string(j),"height", height)){
-                    throw std::runtime_error("Unable to get camera " + std::to_string(i) + " format "+ std::to_string(j) +" height.");
-                }
-
-                if(!getDwordRegistry(HKEY_LOCAL_MACHINE, "SOFTWARE\\Webcamoid\\VirtualCamera\\Cameras\\" + std::to_string(i) + "\\Formats\\" + std::to_string(j),"width", width)){
-                    throw std::runtime_error("Unable to get camera " + std::to_string(i) + " format "+ std::to_string(j) +" width.");
-                }
-                std::cout<< " > height: " << std::to_string(height) << std::endl;
-                std::cout<< " > width: " << std::to_string(width) << std::endl;
-            }
-
-
+        if(number_cameras < 0){
+            throw std::runtime_error("No cameras avaliable. Did you add one device using AkVCamManager add-device?");
         }
 
-    }
+        std::cout<< "Cameras available: " << std::to_string(number_cameras)<<std::endl;
+        
+        if(device.has_value()){
+            std::string device_name = *device;
+            if(ACTIVE_DEVICES.count(device_name) > 0){
+                throw std::invalid_argument("Device " + device_name + " is already in use.");
+            }
+        }
 
+        std::cout<<"Looking for cameras..." <<std::endl;
+
+        //Get info on cameras
+        std::string tmpCameraDesc;
+        std::string tmpCameraID;
+        for(int i = 1; i <= number_cameras; i++){
+
+            std::cout<<"Getting camera " << std::to_string(i) << " info" <<std::endl;
+
+            if(!getStringRegistry(HKEY_LOCAL_MACHINE, "SOFTWARE\\Webcamoid\\VirtualCamera\\Cameras\\" + std::to_string(i),"description", tmpCameraDesc)){
+                throw std::runtime_error("Unable to get camera " + std::to_string(i) + " description.");
+            }
+
+            if(!getStringRegistry(HKEY_LOCAL_MACHINE, "SOFTWARE\\Webcamoid\\VirtualCamera\\Cameras\\" + std::to_string(i),"id", tmpCameraID)){
+                throw std::runtime_error("Unable to get camera " + std::to_string(i) + " id.");
+            }
+
+            std::cout<<"Camera desc: " << tmpCameraDesc <<std::endl;
+            std::cout<<"Camera id: " << tmpCameraID <<std::endl;
+
+            if((device.has_value() && tmpCameraDesc == *device) || (!device.has_value() && ACTIVE_DEVICES.count(tmpCameraDesc) == 0)){
+                std::cout<< "Saving Camera!" << std::endl;
+                _camera_info ={tmpCameraDesc, tmpCameraID};
+                break;
+            }
+        }
+
+
+        if(!_camera_info.has_value() && number_cameras > 0){
+            throw std::runtime_error("All cameras being used...");
+        }
+
+        _width = width;
+        _height = height;
+        _fourcc = libyuv::CanonicalFourCC(fourcc);
+        std::string format;
+        
+        switch(_fourcc) {
+            case libyuv::FOURCC_RAW:
+                format = "RGB24";
+                break;
+            case libyuv::FOURCC_NV12:
+                format = "NV12";
+                break;
+            case libyuv::FOURCC_YUY2:
+                format = "YUY2";
+                break;
+            case libyuv::FOURCC_UYVY:
+                format = "UYVY";
+                break;
+            default:
+                throw std::runtime_error("Unsupported image format.");
+        }
+
+        char cmd[1024];
+
+        memset(cmd, 0, 1024);
+        snprintf(cmd,1024, "\"C:\\Program Files\\AkVirtualCamera\\x64\\AkVCamManager.exe\" stream %s %s %d %d",
+                "AzureDepthCamera", format.c_str(), _width, _height);
+        std::cout << cmd << std::endl;
+
+        // Get the handles to the standard input and standard output.
+        memset(&stream_proc, 0, sizeof(StreamProcess));
+        stream_proc.stdinReadPipe = NULL;
+        stream_proc.stdinWritePipe = NULL;
+        memset(&stream_proc.pipeAttributes, 0, sizeof(SECURITY_ATTRIBUTES));
+        stream_proc.pipeAttributes.nLength = sizeof(SECURITY_ATTRIBUTES);
+        stream_proc.pipeAttributes.bInheritHandle = true;
+        stream_proc.pipeAttributes.lpSecurityDescriptor = NULL;
+        CreatePipe(&stream_proc.stdinReadPipe,&stream_proc.stdinWritePipe,&stream_proc.pipeAttributes,0);
+        SetHandleInformation(stream_proc.stdinWritePipe,HANDLE_FLAG_INHERIT,0);
+
+        STARTUPINFOA startupInfo;
+        memset(&startupInfo, 0, sizeof(STARTUPINFOA));
+        startupInfo.cb = sizeof(STARTUPINFOA);
+        startupInfo.hStdInput = stream_proc.stdinReadPipe;
+        startupInfo.dwFlags = STARTF_USESHOWWINDOW | STARTF_USESTDHANDLES;
+        startupInfo.wShowWindow = SW_HIDE;
+
+        PROCESS_INFORMATION procInfo;
+        memset(&procInfo, 0, sizeof(PROCESS_INFORMATION));
+
+        // Start the stream.
+        if(!CreateProcessA(NULL,cmd,NULL,NULL,true,0,NULL,NULL,&startupInfo,&procInfo)){
+            throw std::runtime_error("Unable to create AkVCam process." + std::to_string(HRESULT_FROM_WIN32(GetLastError())));
+        }
+
+        // Allocate the frame buffer.
+        size_t buffer_size = 3 * _width;
+        buffer = (char *)malloc(buffer_size);
+
+        ACTIVE_DEVICES.insert(_camera_info->desc);
+        _running = true;
+
+    }   
     void stop()
     {
+        if(!_running){
+            return;
+        }
 
+        free(buffer);
+        ACTIVE_DEVICES.erase(_camera_info->desc);
+        _running = false;
+
+        CloseHandle(stream_proc.stdinWritePipe);
+        CloseHandle(stream_proc.stdinReadPipe);
+
+        WaitForSingleObject(stream_proc.procInfo.hProcess, INFINITE);
+        CloseHandle(stream_proc.procInfo.hProcess);
+        CloseHandle(stream_proc.procInfo.hThread);
     }
 
     void send(const uint8_t *frame)
     {
-       
+        if(!_running){
+            return;
+        }
+
+       for (uint32_t y = 0; y < _height; y++) {
+            for (size_t byte = 0; byte < 3*_width; byte++)
+                buffer[byte] = frame[0,0] & 0xff;
+
+            DWORD bytesWritten = 0;
+            WriteFile(stream_proc.stdinWritePipe, buffer,DWORD(3*_width),&bytesWritten,NULL);
+        }
     }
 
     std::string device()

--- a/pyvirtualcam/native_windows_akvcam/virtual_output.h
+++ b/pyvirtualcam/native_windows_akvcam/virtual_output.h
@@ -206,6 +206,13 @@ class VirtualOutput {
             return;
         }
 
+        DWORD processState = WaitForSingleObject(stream_proc.procInfo.hProcess, 0); 
+        if (processState == WAIT_OBJECT_0){
+            throw std::runtime_error("AkVCam stream process not running.");
+        }else{
+            std::cout<<"asdas"<<std::endl;
+        }
+
        for (uint32_t y = 0; y < _height; y++) {
             for (size_t byte = 0; byte < _buffer_size; byte++)
                 _buffer[byte] = frame[0,0] & 0xff;

--- a/pyvirtualcam/native_windows_akvcam/virtual_output.h
+++ b/pyvirtualcam/native_windows_akvcam/virtual_output.h
@@ -150,10 +150,13 @@ class VirtualOutput {
 
         char cmd[1024];
 
+        std::string akvcam_mamanger_path;
+        if(!getStringRegistry(HKEY_LOCAL_MACHINE, "SOFTWARE\\Webcamoid\\VirtualCamera","installPath", akvcam_mamanger_path)){
+            throw std::runtime_error("Unable to get akvcam installation path.");
+        }
+
         memset(cmd, 0, 1024);
-        snprintf(cmd,1024, "\"C:\\Program Files\\AkVirtualCamera\\x64\\AkVCamManager.exe\" stream %s %s %d %d",
-                "AzureDepthCamera", format.c_str(), _width, _height);
-        std::cout << cmd << std::endl;
+        snprintf(cmd, 1024, "\"%s\\x64\\AkVCamManager.exe\" stream %s %s %d %d", akvcam_mamanger_path.c_str(), _camera_info->id.c_str(), format.c_str(), _width, _height);
 
         // Get the handles to the standard input and standard output.
         memset(&stream_proc, 0, sizeof(StreamProcess));

--- a/pyvirtualcam/native_windows_akvcam/virtual_output.h
+++ b/pyvirtualcam/native_windows_akvcam/virtual_output.h
@@ -23,7 +23,8 @@ static std::set<std::string> ACTIVE_DEVICES;
 
 class VirtualOutput {
   private:
-    char * buffer;
+    std::vector<uint8_t> _buffer;
+    size_t _buffer_size;
     std::optional<CameraInfo> _camera_info;
     uint32_t _width;
     uint32_t _height;
@@ -175,8 +176,8 @@ class VirtualOutput {
         }
 
         // Allocate the frame buffer.
-        size_t buffer_size = 3 * _width;
-        buffer = (char *)malloc(buffer_size);
+        _buffer_size = 3 * _width;
+        _buffer.resize(_buffer_size);
 
         ACTIVE_DEVICES.insert(_camera_info->desc);
         _running = true;
@@ -188,7 +189,6 @@ class VirtualOutput {
             return;
         }
 
-        free(buffer);
         ACTIVE_DEVICES.erase(_camera_info->desc);
         _running = false;
 
@@ -207,11 +207,11 @@ class VirtualOutput {
         }
 
        for (uint32_t y = 0; y < _height; y++) {
-            for (size_t byte = 0; byte < 3*_width; byte++)
-                buffer[byte] = frame[0,0] & 0xff;
+            for (size_t byte = 0; byte < _buffer_size; byte++)
+                _buffer[byte] = frame[0,0] & 0xff;
 
             DWORD bytesWritten = 0;
-            WriteFile(stream_proc.stdinWritePipe, buffer,DWORD(3*_width),&bytesWritten,NULL);
+            WriteFile(stream_proc.stdinWritePipe, _buffer.data(),DWORD(_buffer_size),&bytesWritten,NULL);
         }
     }
 

--- a/pyvirtualcam/native_windows_akvcam/virtual_output.h
+++ b/pyvirtualcam/native_windows_akvcam/virtual_output.h
@@ -64,6 +64,29 @@ class VirtualOutput {
                 throw std::runtime_error("Unable to get camera " + std::to_string(i) + " description.");
             }
             std::cout<<cameraDescription << std::endl;
+
+            int cameraFormats;
+            if(!getDwordRegistry(HKEY_LOCAL_MACHINE, "SOFTWARE\\Webcamoid\\VirtualCamera\\Cameras\\" + std::to_string(i) + "\\Formats","size", cameraFormats)){
+                throw std::runtime_error("Unable to get number camera formats");
+            }
+
+            int width;
+            int height;
+            for(int j = 1; j <= cameraFormats; j++){
+
+                std::cout<< "Format #" << std::to_string(j) << ":" << std::endl;
+                if(!getDwordRegistry(HKEY_LOCAL_MACHINE, "SOFTWARE\\Webcamoid\\VirtualCamera\\Cameras\\" + std::to_string(i) + "\\Formats\\" + std::to_string(j),"height", height)){
+                    throw std::runtime_error("Unable to get camera " + std::to_string(i) + " format "+ std::to_string(j) +" height.");
+                }
+
+                if(!getDwordRegistry(HKEY_LOCAL_MACHINE, "SOFTWARE\\Webcamoid\\VirtualCamera\\Cameras\\" + std::to_string(i) + "\\Formats\\" + std::to_string(j),"width", width)){
+                    throw std::runtime_error("Unable to get camera " + std::to_string(i) + " format "+ std::to_string(j) +" width.");
+                }
+                std::cout<< " > height: " << std::to_string(height) << std::endl;
+                std::cout<< " > width: " << std::to_string(width) << std::endl;
+            }
+
+
         }
 
     }

--- a/pyvirtualcam/native_windows_akvcam/virtual_output.h
+++ b/pyvirtualcam/native_windows_akvcam/virtual_output.h
@@ -209,8 +209,6 @@ class VirtualOutput {
         DWORD processState = WaitForSingleObject(stream_proc.procInfo.hProcess, 0); 
         if (processState == WAIT_OBJECT_0){
             throw std::runtime_error("AkVCam stream process not running.");
-        }else{
-            std::cout<<"asdas"<<std::endl;
         }
 
        for (uint32_t y = 0; y < _height; y++) {

--- a/pyvirtualcam/native_windows_akvcam/virtual_output.h
+++ b/pyvirtualcam/native_windows_akvcam/virtual_output.h
@@ -208,6 +208,7 @@ class VirtualOutput {
 
         DWORD processState = WaitForSingleObject(stream_proc.procInfo.hProcess, 0); 
         if (processState == WAIT_OBJECT_0){
+            stop();
             throw std::runtime_error("AkVCam stream process not running.");
         }
       

--- a/pyvirtualcam/native_windows_akvcam/virtual_output.h
+++ b/pyvirtualcam/native_windows_akvcam/virtual_output.h
@@ -231,6 +231,6 @@ class VirtualOutput {
     }
 
     uint32_t native_fourcc() {
-        return libyuv::FOURCC_YUY2;
+        return _fourcc;
     }
 };

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,14 @@ if platform.system() == 'Windows':
             language='c++'
         )
     )
+    ext_modules.append(
+        Extension('pyvirtualcam._native_windows_akvcam',
+            sorted(['pyvirtualcam/native_windows_akvcam/main.cpp'] + common_src),
+            include_dirs=['pyvirtualcam/_native_windows_akvcam'] + common_inc,
+            extra_link_args=["/DEFAULTLIB:advapi32.lib"],
+            language='c++'
+        )
+    )
 elif platform.system() == 'Darwin':
     ext_modules.append(
         Extension('pyvirtualcam._native_macos_obs',


### PR DESCRIPTION
Follows the discussion on https://github.com/letmaik/pyvirtualcam/discussions/87

This PR still needs to handle:
- [x] The registry has the install path of akvcam, which should be used to construct the full exe path.
- [x] Instead of C buffers, let's use std::vector<uint8_t>, then memory gets deallocated automatically
- [x] Can a frame be written to stdin in full or does it have to be line by line? The former would be simpler
- [x] The external process may exit at any point which needs to be handled
- [x] Fix unresolved camera name references
