### PR TITLE
Linux: rethrow exceptions correctly

### DIFF
--- a/.github/scripts/test-windows.ps1
+++ b/.github/scripts/test-windows.ps1
@@ -97,7 +97,7 @@ exec { python -m pip install -r dev-requirements.txt }
 
 # Install test helper package
 Push-Location test/win-dshow-capture
-exec { python -m pip install wheel }
+exec { python -m pip install wheel setuptools }
 exec { python -u setup.py bdist_wheel }
 python -m pip uninstall -y pyvirtualcam_win_dshow_capture
 ls dist\*cp${PYVER}*win*.whl | % { exec { python -m pip install $_ } }

--- a/pyvirtualcam/native_linux_v4l2loopback/virtual_output.h
+++ b/pyvirtualcam/native_linux_v4l2loopback/virtual_output.h
@@ -130,7 +130,7 @@ class VirtualOutput {
             } catch (std::exception &ex) {
                 close(_camera_fd);
                 _camera_fd = -1;
-                throw ex;
+                throw;
             }
         };
 


### PR DESCRIPTION
Otherwise exception messages are not kept and the exception message will be "std::exception".

See https://github.com/letmaik/pyvirtualcam/issues/61.