### PR TITLE
Added linux aarch64/AMD64 build support

### DIFF
--- a/.github/scripts/build-linux.sh
+++ b/.github/scripts/build-linux.sh
@@ -26,6 +26,7 @@ fi
 
 # install compile-time dependencies
 ${PYBIN}/pip install numpy==${NUMPY_VERSION}
+${PYBIN}/pip install setuptools
 
 # List installed packages
 ${PYBIN}/pip freeze

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,9 +433,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
-    - name: Set up QEMU (Linux ARM64)
-      uses: docker/setup-qemu-action@v2
    
     - name: Setup Python
       uses: actions/setup-python@v4
@@ -451,7 +448,7 @@ jobs:
 
     - name: Install from wheel
       run: |
-        pip install dist/pyvirtualcam*cp310-manylinux*.whl
+        pip install dist/pyvirtualcam*cp310-manylinux*_x86_64.whl
         pip install -r dev-requirements.txt
 
     - name: Build docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,10 +173,19 @@ jobs:
     #     setup-python-dependencies: false
 
     - name: Build wheel (Linux)
-      if: matrix.config.os-name == 'linux'
+      if: matrix.config.os-name == 'linux'&& matrix.config.python-arch == 'x86_64'
       # See comment above.
       # run: .github/scripts/build-linux.sh
       run: docker run --rm -e PYTHON_VERSION -e NUMPY_VERSION -w /io -v `pwd`:/io ${{ matrix.config.docker-image }} /io/.github/scripts/build-linux.sh
+      env:
+        PYTHON_VERSION: ${{ matrix.config.python-version }}
+        NUMPY_VERSION: ${{ matrix.config.numpy-version }}
+
+    - name: Build wheel (Linux ARM64)
+      if: matrix.config.os-name == 'linux' && matrix.config.python-arch == 'aarch64'
+      # See comment above.
+      # run: .github/scripts/build-linux.sh
+      run: docker run --rm --platform linux/arm64 -e PYTHON_VERSION -e NUMPY_VERSION -w /io -v `pwd`:/io ${{ matrix.config.docker-image }} /io/.github/scripts/build-linux.sh
       env:
         PYTHON_VERSION: ${{ matrix.config.python-version }}
         NUMPY_VERSION: ${{ matrix.config.numpy-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,7 +382,7 @@ jobs:
     - name: Test wheel (Linux ARM64)
       if: matrix.config.os-name == 'linux' && matrix.config.python-arch == 'aarch64'
       # run: .github/scripts/test-linux.sh
-      run: docker run --rm --platform linux/arm64 -e PYTHON_VERSION -w /io -v `pwd`:/io ${{ matrix.config.docker-image }} /io/.github/scripts/test-linux.sh
+      run: docker run --rm -e PYTHON_VERSION -w /io -v `pwd`:/io ${{ matrix.config.docker-image }} /io/.github/scripts/test-linux.sh
       env:
         PYTHON_VERSION: ${{ matrix.config.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
 
     - name: Set up QEMU (Linux ARM64)
       if: matrix.config.os-name == 'linux' && matrix.config.python-arch == 'aarch64'
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Build wheel (Linux)
       if: matrix.config.os-name == 'linux'
@@ -361,7 +361,7 @@ jobs:
 
     - name: Set up QEMU (Linux ARM64)
       if: matrix.config.os-name == 'linux' && matrix.config.python-arch == 'aarch64'
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Test wheel (Linux)
       if: matrix.config.os-name == 'linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,31 @@ jobs:
           python-version: '3.12'
           numpy-version: '2.0.*'
 
+        - os-image: ubuntu-latest
+          os-name: linux
+          docker-image: quay.io/pypa/manylinux_2_28_aarch64
+          python-arch: 'aarch64'
+          python-version: '3.9'
+          numpy-version: '2.0.*'
+        - os-image: ubuntu-latest
+          os-name: linux
+          docker-image: quay.io/pypa/manylinux_2_28_aarch64
+          python-arch: 'aarch64'
+          python-version: '3.10'
+          numpy-version: '2.0.*'
+        - os-image: ubuntu-latest
+          os-name: linux
+          docker-image: quay.io/pypa/manylinux_2_28_aarch64
+          python-arch: 'aarch64'
+          python-version: '3.11'
+          numpy-version: '2.0.*'
+        - os-image: ubuntu-latest
+          os-name: linux
+          docker-image: quay.io/pypa/manylinux_2_28_aarch64
+          python-arch: 'aarch64'
+          python-version: '3.12'
+          numpy-version: '2.0.*'
+
         - os-image: macos-12
           os-name: mac
           python-arch: x86_64
@@ -221,6 +246,31 @@ jobs:
           os-name: linux
           docker-image: quay.io/pypa/manylinux2014_x86_64
           python-arch: 'x86_64'
+          python-version: '3.12'
+          numpy-version: '2.0.*'
+
+        - os-image: ubuntu-latest
+          os-name: linux
+          docker-image: quay.io/pypa/manylinux_2_28_aarch64
+          python-arch: 'aarch64'
+          python-version: '3.9'
+          numpy-version: '2.0.*'
+        - os-image: ubuntu-latest
+          os-name: linux
+          docker-image: quay.io/pypa/manylinux_2_28_aarch64
+          python-arch: 'aarch64'
+          python-version: '3.10'
+          numpy-version: '2.0.*'
+        - os-image: ubuntu-latest
+          os-name: linux
+          docker-image: quay.io/pypa/manylinux_2_28_aarch64
+          python-arch: 'aarch64'
+          python-version: '3.11'
+          numpy-version: '2.0.*'
+        - os-image: ubuntu-latest
+          os-name: linux
+          docker-image: quay.io/pypa/manylinux_2_28_aarch64
+          python-arch: 'aarch64'
           python-version: '3.12'
           numpy-version: '2.0.*'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
       if: matrix.config.os-name == 'linux' && matrix.config.python-arch == 'aarch64'
       # See comment above.
       # run: .github/scripts/build-linux.sh
-      run: docker run --rm --platform linux/arm64 -e PYTHON_VERSION -e NUMPY_VERSION -w /io -v `pwd`:/io ${{ matrix.config.docker-image }} /io/.github/scripts/build-linux.sh
+      run: docker run --rm -e PYTHON_VERSION -e NUMPY_VERSION -w /io -v `pwd`:/io ${{ matrix.config.docker-image }} /io/.github/scripts/build-linux.sh
       env:
         PYTHON_VERSION: ${{ matrix.config.python-version }}
         NUMPY_VERSION: ${{ matrix.config.numpy-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,9 +369,20 @@ jobs:
         path: dist
 
     - name: Test wheel (Linux)
-      if: matrix.config.os-name == 'linux'
+      if: matrix.config.os-name == 'linux'&& matrix.config.python-arch == 'x86_64'
       # run: .github/scripts/test-linux.sh
       run: docker run --rm -e PYTHON_VERSION -w /io -v `pwd`:/io ${{ matrix.config.docker-image }} /io/.github/scripts/test-linux.sh
+      env:
+        PYTHON_VERSION: ${{ matrix.config.python-version }}
+
+    - name: Set up QEMU (Linux ARM64)
+      if: matrix.config.os-name == 'linux' && matrix.config.python-arch == 'aarch64'
+      uses: docker/setup-qemu-action@v2
+
+    - name: Test wheel (Linux ARM64)
+      if: matrix.config.os-name == 'linux' && matrix.config.python-arch == 'aarch64'
+      # run: .github/scripts/test-linux.sh
+      run: docker run --rm --platform linux/arm64 -e PYTHON_VERSION -w /io -v `pwd`:/io ${{ matrix.config.docker-image }} /io/.github/scripts/test-linux.sh
       env:
         PYTHON_VERSION: ${{ matrix.config.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           python-arch: 'x86_64'
           python-version: '3.12'
           numpy-version: '2.0.*'
-
+          #ARM 64
         - os-image: ubuntu-latest
           os-name: linux
           docker-image: quay.io/pypa/manylinux_2_28_aarch64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,6 +433,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Set up QEMU (Linux ARM64)
+      if: matrix.config.os-name == 'linux' && matrix.config.python-arch == 'aarch64'
+      uses: docker/setup-qemu-action@v2
    
     - name: Setup Python
       uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,11 +181,12 @@ jobs:
         PYTHON_VERSION: ${{ matrix.config.python-version }}
         NUMPY_VERSION: ${{ matrix.config.numpy-version }}
 
+    - name: Set up QEMU (Linux ARM64)
+      if: matrix.config.os-name == 'linux' && matrix.config.python-arch == 'aarch64'
+      uses: docker/setup-qemu-action@v2
+
     - name: Build wheel (Linux ARM64)
       if: matrix.config.os-name == 'linux' && matrix.config.python-arch == 'aarch64'
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-    - name: Run Docker
       # See comment above.
       # run: .github/scripts/build-linux.sh
       run: docker run --rm --platform linux/arm64 -e PYTHON_VERSION -e NUMPY_VERSION -w /io -v `pwd`:/io ${{ matrix.config.docker-image }} /io/.github/scripts/build-linux.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,21 +172,12 @@ jobs:
     #     languages: python, cpp
     #     setup-python-dependencies: false
 
-    - name: Build wheel (Linux)
-      if: matrix.config.os-name == 'linux'&& matrix.config.python-arch == 'x86_64'
-      # See comment above.
-      # run: .github/scripts/build-linux.sh
-      run: docker run --rm -e PYTHON_VERSION -e NUMPY_VERSION -w /io -v `pwd`:/io ${{ matrix.config.docker-image }} /io/.github/scripts/build-linux.sh
-      env:
-        PYTHON_VERSION: ${{ matrix.config.python-version }}
-        NUMPY_VERSION: ${{ matrix.config.numpy-version }}
-
     - name: Set up QEMU (Linux ARM64)
       if: matrix.config.os-name == 'linux' && matrix.config.python-arch == 'aarch64'
       uses: docker/setup-qemu-action@v2
 
-    - name: Build wheel (Linux ARM64)
-      if: matrix.config.os-name == 'linux' && matrix.config.python-arch == 'aarch64'
+    - name: Build wheel (Linux)
+      if: matrix.config.os-name == 'linux'
       # See comment above.
       # run: .github/scripts/build-linux.sh
       run: docker run --rm -e PYTHON_VERSION -e NUMPY_VERSION -w /io -v `pwd`:/io ${{ matrix.config.docker-image }} /io/.github/scripts/build-linux.sh
@@ -368,19 +359,12 @@ jobs:
         name: wheel-${{ matrix.config.os-name }}-${{ matrix.config.python-arch }}-${{ matrix.config.python-version }}
         path: dist
 
-    - name: Test wheel (Linux)
-      if: matrix.config.os-name == 'linux'&& matrix.config.python-arch == 'x86_64'
-      # run: .github/scripts/test-linux.sh
-      run: docker run --rm -e PYTHON_VERSION -w /io -v `pwd`:/io ${{ matrix.config.docker-image }} /io/.github/scripts/test-linux.sh
-      env:
-        PYTHON_VERSION: ${{ matrix.config.python-version }}
-
     - name: Set up QEMU (Linux ARM64)
       if: matrix.config.os-name == 'linux' && matrix.config.python-arch == 'aarch64'
       uses: docker/setup-qemu-action@v2
 
-    - name: Test wheel (Linux ARM64)
-      if: matrix.config.os-name == 'linux' && matrix.config.python-arch == 'aarch64'
+    - name: Test wheel (Linux)
+      if: matrix.config.os-name == 'linux'
       # run: .github/scripts/test-linux.sh
       run: docker run --rm -e PYTHON_VERSION -w /io -v `pwd`:/io ${{ matrix.config.docker-image }} /io/.github/scripts/test-linux.sh
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,7 +435,6 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up QEMU (Linux ARM64)
-      if: matrix.config.os-name == 'linux' && matrix.config.python-arch == 'aarch64'
       uses: docker/setup-qemu-action@v2
    
     - name: Setup Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-
+    
     # - name: Initialize CodeQL
     #   if: matrix.config.python-version == '3.10'
     #   uses: github/codeql-action/init@v3
@@ -183,6 +183,9 @@ jobs:
 
     - name: Build wheel (Linux ARM64)
       if: matrix.config.os-name == 'linux' && matrix.config.python-arch == 'aarch64'
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Run Docker
       # See comment above.
       # run: .github/scripts/build-linux.sh
       run: docker run --rm --platform linux/arm64 -e PYTHON_VERSION -e NUMPY_VERSION -w /io -v `pwd`:/io ${{ matrix.config.docker-image }} /io/.github/scripts/build-linux.sh


### PR DESCRIPTION
Simply adapted CI.yml file to build the ARM64 version of the wheel.

Build not working on both python 3.12 on linux. The issue was alread present when I forked so I suppose it's ""normal"". If I have some time available I might try to also fix this issue

Closes #122 